### PR TITLE
Update vulnerable package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,12 @@
                   "src/pubcontrolclient.php",
                   "src/pubcontrol.php"]
     },
+    "autoload-dev": {
+        "files": [
+            "tests/CallbackTestClass.php",
+            "tests/ItemTestClass.php"
+        ]
+    },
     "target-dir": "fanout/php-pubcontrol",
     "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "firebase/php-jwt": "^1.0.0"
     },    
     "require-dev": {
-        "phpunit/phpunit": "3.7.14"
+        "phpunit/phpunit": "~4.8"
     },
     "autoload": {
         "files": ["src/format.php",
@@ -24,5 +24,5 @@
                   "src/pubcontrol.php"]
     },
     "target-dir": "fanout/php-pubcontrol",
-    "minimum-stability": "dev"
+    "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "firebase/php-jwt": "^1.0.0"
-    },    
+        "firebase/php-jwt": "~3.0"
+    },
     "require-dev": {
         "phpunit/phpunit": "~4.8"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit colors="true"
+        bootstrap="./vendor/autoload.php">
     <testsuites>
         <testsuite name="Test Suite">
-            <directory>./tests/</directory>
+            <directory suffix="tests.php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/pccutilities.php
+++ b/src/pccutilities.php
@@ -70,6 +70,8 @@ class PccUtilities
             $claim = $auth_jwt_claim;
             if (!array_key_exists('exp', $claim))
                 $claim['exp'] = time() + 3600;
+
+            // Signed with HS256 by default
             return 'Bearer ' . \Firebase\JWT\JWT::encode($claim, $auth_jwt_key);
         }
         else 

--- a/src/pccutilities.php
+++ b/src/pccutilities.php
@@ -70,7 +70,7 @@ class PccUtilities
             $claim = $auth_jwt_claim;
             if (!array_key_exists('exp', $claim))
                 $claim['exp'] = time() + 3600;
-            return 'Bearer ' . \JWT::encode($claim, $auth_jwt_key); 
+            return 'Bearer ' . \Firebase\JWT\JWT::encode($claim, $auth_jwt_key);
         }
         else 
             return null;

--- a/tests/CallbackTestClass.php
+++ b/tests/CallbackTestClass.php
@@ -1,0 +1,19 @@
+<?php
+
+class CallbackTestClass extends Stackable
+{
+    public $was_callback_called = false;
+    public $result = null;
+    public $message = null;
+
+    public function callback($result, $message)
+    {
+        $this->result = $result;
+        $this->message = $message;
+        $this->was_callback_called = true;
+    }
+
+    public function run()
+    {
+    }
+}

--- a/tests/ItemTestClass.php
+++ b/tests/ItemTestClass.php
@@ -1,0 +1,9 @@
+<?php
+
+class ItemTestClass
+{
+    public function export()
+    {
+        return array('name' => 'export');
+    }
+}

--- a/tests/pcccbhandler_tests.php
+++ b/tests/pcccbhandler_tests.php
@@ -1,23 +1,5 @@
 <?php
 
-class CallbackTestClass extends Stackable
-{
-    public $was_callback_called = false;
-    public $result = null;
-    public $message = null;
-
-    public function callback($result, $message)
-    {
-        $this->result = $result;
-        $this->message = $message;
-        $this->was_callback_called = true;
-    }
-
-    public function run()
-    {
-    }
-}
-
 class PubControlClientCallbackHandlerTests extends PHPUnit_Framework_TestCase
 {
     public function testInitialize()

--- a/tests/pccutilities_tests.php
+++ b/tests/pccutilities_tests.php
@@ -102,6 +102,8 @@ class PccUtilitiesTests extends PHPUnit_Framework_TestCase
         $pccu = new PubControl\PccUtilities();
         $header = $pccu->gen_auth_header(array('claim' => 'hello', 'exp' =>
             1000), 'key==', null, null);
+
+        // Header is {"typ":"JWT","alg":"HS256"}{"claim":"hello","exp":1000}
         $this->assertEquals($header, 'Bearer eyJ0eXAiOiJKV1QiLCJhb' .
                 'GciOiJIUzI1NiJ9.eyJjbGFpbSI6ImhlbGxvIiwiZXhwIjoxMDAwfQ.-' .
                 'de7_nwFHcDuvyAX2ptOKpTdDKJNw3WmOPK2oQ8vpS4');

--- a/tests/pccutilities_tests.php
+++ b/tests/pccutilities_tests.php
@@ -102,12 +102,12 @@ class PccUtilitiesTests extends PHPUnit_Framework_TestCase
         $pccu = new PubControl\PccUtilities();
         $header = $pccu->gen_auth_header(array('claim' => 'hello', 'exp' =>
             1000), 'key==', null, null);
-        $this->assertEquals($header, 'Bearer eyJ0eXAiOiJKV1QiLCJhb' . 
+        $this->assertEquals($header, 'Bearer eyJ0eXAiOiJKV1QiLCJhb' .
                 'GciOiJIUzI1NiJ9.eyJjbGFpbSI6ImhlbGxvIiwiZXhwIjoxMDAwfQ.-' .
                 'de7_nwFHcDuvyAX2ptOKpTdDKJNw3WmOPK2oQ8vpS4');
         $header = $pccu->gen_auth_header(array('claim' => 'hello'),
                 'key==', null, null);
-        $claim = JWT::decode(substr($header, 7), 'key==');
+        $claim = Firebase\JWT\JWT::decode(substr($header, 7), 'key==', ['HS256']);
         $this->assertTrue(array_key_exists('exp', $claim));
     }
 }

--- a/tests/pubcontrol_tests.php
+++ b/tests/pubcontrol_tests.php
@@ -55,24 +55,6 @@ class PubControlTestClassNoAsync extends PubControl\PubControl
     }
 }
 
-class CallbackTestClass extends Stackable
-{
-    public $was_callback_called = false;
-    public $result = null;
-    public $message = null;
-
-    public function callback($result, $message)
-    {
-        $this->result = $result;
-        $this->message = $message;
-        $this->was_callback_called = true;
-    }
-
-    public function run()
-    {
-    }
-}
-
 class TestPubControl extends PHPUnit_Framework_TestCase
 {
     public function testInitialize()

--- a/tests/pubcontrolclient_tests.php
+++ b/tests/pubcontrolclient_tests.php
@@ -8,14 +8,6 @@ class NoAsyncPubControlClientClass extends PubControl\PubControlClient
     }
 }
 
-class ItemTestClass
-{
-    public function export()
-    {
-        return array('name' => 'export');
-    }
-}
-
 class ThreadSafeClientTestClass
 {
     public $was_publish_called = false;

--- a/tests/threadsafeclient_tests.php
+++ b/tests/threadsafeclient_tests.php
@@ -1,13 +1,5 @@
 <?php
 
-class ItemTestClass
-{
-    public function export()
-    {
-        return array('name' => 'export');
-    }
-}
-
 class ThreadSafeClientForTesting1 extends PubControl\ThreadSafeClient
 {
     public $was_ensure_thread_called = false;
@@ -50,7 +42,7 @@ class ThreadSafeClientForTesting2 extends PubControl\ThreadSafeClient
     }
 }
 
-class PccUtilitiesTestClass extends Stackable
+class PccUtilitiesStackableTestClass extends Stackable
 {
     public $was_pubcall_called = false;
     public $uri = false;
@@ -74,25 +66,7 @@ class PccUtilitiesFailureTestClass extends Stackable
 {
     public function pubcall($uri, $auth, $content)
     {
-        throw new RuntimeException('message');    
-    }
-
-    public function run()
-    {
-    }
-}
-
-class CallbackTestClass extends Stackable
-{
-    public $was_callback_called = false;
-    public $result = null;
-    public $message = null;
-
-    public function callback($result, $message)
-    {
-        $this->result = $result;
-        $this->message = $message;
-        $this->was_callback_called = true;
+        throw new RuntimeException('message');
     }
 
     public function run()
@@ -106,7 +80,7 @@ class TestThreadSafeClient extends PHPUnit_Framework_TestCase
     {
         $req_queue = new PubControl\ThreadSafeArray();
         $pc = new PubControl\ThreadSafeClient('uri', $req_queue);
-        $this->assertEquals($pc->uri, 'uri'); 
+        $this->assertEquals($pc->uri, 'uri');
         $this->assertEquals($pc->req_queue, $req_queue);
         $this->assertFalse(is_null($pc->mutex));
         $this->assertFalse(is_null($pc->pcc_utilities));
@@ -118,7 +92,7 @@ class TestThreadSafeClient extends PHPUnit_Framework_TestCase
         $pc = new PubControl\ThreadSafeClient('uri', $req_queue);
         $pc->set_auth_basic('user', 'pass');
         $this->assertEquals($pc->auth_basic_user, 'user');
-        $this->assertEquals($pc->auth_basic_pass, 'pass');  
+        $this->assertEquals($pc->auth_basic_pass, 'pass');
     }
 
     public function testSetAuthJwt()
@@ -127,7 +101,7 @@ class TestThreadSafeClient extends PHPUnit_Framework_TestCase
         $pc = new PubControl\ThreadSafeClient('uri', $req_queue);
         $pc->set_auth_basic('claim', 'key');
         $this->assertEquals($pc->auth_basic_user, 'claim');
-        $this->assertEquals($pc->auth_basic_pass, 'key'); 
+        $this->assertEquals($pc->auth_basic_pass, 'key');
     }
 
     public function testPublishAsync()
@@ -169,7 +143,7 @@ class TestThreadSafeClient extends PHPUnit_Framework_TestCase
         $pc->ensure_thread();
         foreach (range(0, 500) as $number)
         {
-            $pc->queue_req(array('pub', 'uri', 'auth', 
+            $pc->queue_req(array('pub', 'uri', 'auth',
                     'export', 'callback'));
         }
         $pc->queue_req(array('stop'));
@@ -217,7 +191,7 @@ class TestThreadSafeClient extends PHPUnit_Framework_TestCase
     {
         $req_queue = new PubControl\ThreadSafeArray();
         $pc = new PubControl\ThreadSafeClient('uri', $req_queue);
-        $utilities = new PccUtilitiesTestClass();
+        $utilities = new PccUtilitiesStackableTestClass();
         $pc->pcc_utilities = $utilities;
         $callback1 = new CallbackTestClass();
         $callback2 = new CallbackTestClass();


### PR DESCRIPTION
-  Sensiolabs reports that firebase/php-jwt versions <2.0.0 has a vulnerability. https://security.sensiolabs.org/database?package=firebase/php-jwt
- Upgrading the dependency requires no breaking changes - it still supports PHP 5.3
- Updating PHPUnit and the test suite makes sure that the tests can be easily run
